### PR TITLE
Fix order of arguments in examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ main = runTest do
     test "arithmetic" do
       Assert.assert "2 + 2 should be 4" $ (2 + 2) == 4
       Assert.assertFalse "2 + 2 shouldn't be 5" $ (2 + 2) == 5
-      Assert.equal (2 + 2) 4
-      Assert.expectFailure "2 + 2 shouldn't be 5" $ Assert.equal (2 + 2) 5
+      Assert.equal 4 (2 + 2)
+      Assert.expectFailure "2 + 2 shouldn't be 5" $ Assert.equal 5 (2 + 2)
   suite "async code" do
     test "with async IO" do
       fileContents <- FS.readTextFile UTF8 "file.txt"


### PR DESCRIPTION
This updates the examples to pass `expected` then `actual` since the functions are defined that way.

I got confused by these examples since they imply that the functions should be called with `actual` then `expected`, which was misleading in the test failure output.